### PR TITLE
fix: update readme and tsconfig to work with vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The latest version of our library can be found at [this link](https://master--61
 
 > npm install
 > npm run storybook
+> make sure you are using node 16 before running the project
 
 ## Integrating
 
@@ -47,7 +48,7 @@ const Component = () => {
 
   > Pass options or overrides to the base theme.
   > This is so that each project can configure the library to their own profile.
-  
+
 ## Updating package
 
 - You need a personal token with read and write access. The token can be created [here](https://github.com/settings/tokens)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -22,11 +18,6 @@
     "declaration": true,
     "outDir": "./lib"
   },
-  "include": [
-    "src/components"
-, "src/components/Theme/.tsx"  ],
-  "exclude": [
-    "node_modules",
-    "**/__tests__/*"
-  ]
+  "include": ["src/components", "src/components/Theme/.tsx"],
+  "exclude": ["node_modules", "**/__tests__/*"]
 }


### PR DESCRIPTION
- Add some description for using correct node version, i'm using nvm and node version 18 by default which didn't work so changed it to 16 and was able to run the project locally successfully
- Small fix in tsconfig to work with vite when imported as module