### PR TITLE
fix: add type for children in ThemeProvider

### DIFF
--- a/src/components/Theme/ThemeProvider.tsx
+++ b/src/components/Theme/ThemeProvider.tsx
@@ -12,6 +12,7 @@ import { baseThemeOptions, baseTheme } from "./baseTheme";
 
 interface ThemeProviderProps {
   options?: ThemeOptions;
+  children: React.ReactNode;
 }
 
 const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, options }) => {


### PR DESCRIPTION
React 18 was complaining for type so I added this small fix