### PR TITLE
fix: remove width and height

### DIFF
--- a/src/components/Nyckeltal/Nyckeltal.tsx
+++ b/src/components/Nyckeltal/Nyckeltal.tsx
@@ -13,8 +13,6 @@ export default function Nyckeltal({ item, boxShadow = true }: Props) {
         borderRadius: "20px",
         boxShadow: boxShadow ? "0px 2px 10px 0px rgb(0 0 0 / 10%)" : "none",
         border: boxShadow ? "" : "1px solid rgba(0, 0, 0, 0.12)",
-        width: "100%",
-        height: "104px",
         padding: "16px",
         background: "#fff",
       }}


### PR DESCRIPTION
Dem här CSS raderna gjorde så att width och height såg annorlunda ut i pdf:en. Dem behövs dock inte längre för att uppnå den stylingen vi vill ha varken i PDF eller i resultatvyn.