### PR TITLE
fix: add breakpoints for header component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.4.5-fix-a20blfh-908.0",
+  "version": "1.4.6-fix-a20blfh-908.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.4.5-fix-a20blfh-908.0",
+      "version": "1.4.6-fix-a20blfh-908.0",
       "devDependencies": {
         "@babel/core": "^7.20.12",
         "@mui/icons-material": "^5.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.4.4-fix-a20blfh-908.0",
+  "version": "1.4.5-fix-a20blfh-908.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.4.4-fix-a20blfh-908.0",
+      "version": "1.4.5-fix-a20blfh-908.0",
       "devDependencies": {
         "@babel/core": "^7.20.12",
         "@mui/icons-material": "^5.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.4.3",
+  "version": "1.4.4-fix-a20blfh-908.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.4.3",
+      "version": "1.4.4-fix-a20blfh-908.0",
       "devDependencies": {
         "@babel/core": "^7.20.12",
         "@mui/icons-material": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.4.5-fix-a20blfh-908.0",
+  "version": "1.4.6-fix-a20blfh-908.0",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.4.4-fix-a20blfh-908.0",
+  "version": "1.4.5-fix-a20blfh-908.0",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.4.3",
+  "version": "1.4.4-fix-a20blfh-908.0",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -38,12 +38,15 @@ export default function Header({
     <AppBar sx={{ height: 78 }} position="fixed" visible={true} elevation={1}>
       <Toolbar
         disableGutters={true}
-        sx={{
+        sx={(theme) => ({
           display: "flex",
           justifyContent: "space-between",
           px: 5,
           py: 3,
-        }}
+          [theme.breakpoints.down("sm")]: {
+            px: 2,
+          },
+        })}
       >
         <MuiLink
           to="/"

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -35,7 +35,7 @@ export default function Header({
   agronodLogo,
 }: IProps) {
   return (
-    <AppBar position="fixed" visible={true} elevation={1}>
+    <AppBar sx={{ height: 78 }} position="fixed" visible={true} elevation={1}>
       <Toolbar
         disableGutters={true}
         sx={{
@@ -63,16 +63,6 @@ export default function Header({
         >
           <>
             {menuLinks && menuLinks}
-
-            {!agronodLogo && (
-              <MuiLink
-                href="https://www.agronod.com/sv/om-agrosfar"
-                target="_blank"
-                underline="none"
-              >
-                <Typography variant="body1">Om Agrosfär</Typography>
-              </MuiLink>
-            )}
             {userDropdown && userDropdown}
           </>
         </Stack>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -43,7 +43,7 @@ export default function Header({
           justifyContent: "space-between",
           px: 5,
           py: 3,
-          [theme.breakpoints.down("sm")]: {
+          [theme.breakpoints.down("md")]: {
             px: 2,
           },
         })}


### PR DESCRIPTION
Added breakpoint rules and removed the link to Agronod, will use it directly in the project instead as {children} 

Jira ticket: https://agronod.atlassian.net/jira/software/c/projects/A20BLFH/boards/7?modal=detail&selectedIssue=A20BLFH-908&assignee=63316a68409249995ee9585e