### PR TITLE
fix: default style rules for LoadingCircular

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.5.5-fix-loader-circular.0",
+  "version": "1.5.6-fix-loader-circular.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.5.5-fix-loader-circular.0",
+      "version": "1.5.6-fix-loader-circular.0",
       "devDependencies": {
         "@babel/core": "^7.20.12",
         "@mui/icons-material": "^5.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.5.7-fix-loader-circular.0",
+  "version": "1.5.8-fix-loader-circular.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.5.7-fix-loader-circular.0",
+      "version": "1.5.8-fix-loader-circular.0",
       "devDependencies": {
         "@babel/core": "^7.20.12",
         "@mui/icons-material": "^5.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.5.4",
+  "version": "1.5.5-fix-loader-circular.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.5.4",
+      "version": "1.5.5-fix-loader-circular.0",
       "devDependencies": {
         "@babel/core": "^7.20.12",
         "@mui/icons-material": "^5.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.5.6-fix-loader-circular.0",
+  "version": "1.5.7-fix-loader-circular.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.5.6-fix-loader-circular.0",
+      "version": "1.5.7-fix-loader-circular.0",
       "devDependencies": {
         "@babel/core": "^7.20.12",
         "@mui/icons-material": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.5.6-fix-loader-circular.0",
+  "version": "1.5.7-fix-loader-circular.0",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.5.7-fix-loader-circular.0",
+  "version": "1.5.8-fix-loader-circular.0",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.5.4",
+  "version": "1.5.5-fix-loader-circular.0",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.5.5-fix-loader-circular.0",
+  "version": "1.5.6-fix-loader-circular.0",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/src/components/Loaders/LoadingCircular/LoaderCircular.tsx
+++ b/src/components/Loaders/LoadingCircular/LoaderCircular.tsx
@@ -10,7 +10,8 @@ type LoaderCircularBaseProps = Pick<
 >;
 
 export interface LoaderCircularProps extends LoaderCircularBaseProps {
-  align: string;
+  align?: string;
+  justify?: string;
 }
 
 const LoaderCircular = ({ ...props }: LoaderCircularProps) => {
@@ -19,7 +20,8 @@ const LoaderCircular = ({ ...props }: LoaderCircularProps) => {
       sx={{
         display: "flex",
         width: "100%",
-        justifyContent: props.align,
+        justifyContent: props.justify || "center",
+        alignItems: props.align || "center",
       }}
     >
       <MuiCircularProgress

--- a/src/components/Loaders/LoadingCircular/LoaderCircular.tsx
+++ b/src/components/Loaders/LoadingCircular/LoaderCircular.tsx
@@ -2,6 +2,8 @@ import {
   Box,
   CircularProgress as MuiCircularProgress,
   CircularProgressProps as MuiCircularProgressProps,
+  SxProps,
+  Theme,
 } from "@mui/material";
 
 type LoaderCircularBaseProps = Pick<
@@ -12,7 +14,7 @@ type LoaderCircularBaseProps = Pick<
 export interface LoaderCircularProps extends LoaderCircularBaseProps {
   align?: string;
   justify?: string;
-  sx?: any;
+  sx?: SxProps<Theme>;
 }
 
 const LoaderCircular = ({ ...props }: LoaderCircularProps) => {

--- a/src/components/Loaders/LoadingCircular/LoaderCircular.tsx
+++ b/src/components/Loaders/LoadingCircular/LoaderCircular.tsx
@@ -12,6 +12,7 @@ type LoaderCircularBaseProps = Pick<
 export interface LoaderCircularProps extends LoaderCircularBaseProps {
   align?: string;
   justify?: string;
+  sx?: any;
 }
 
 const LoaderCircular = ({ ...props }: LoaderCircularProps) => {
@@ -22,6 +23,8 @@ const LoaderCircular = ({ ...props }: LoaderCircularProps) => {
         width: "100%",
         justifyContent: props.justify || "center",
         alignItems: props.align || "center",
+        height: "100%",
+        ...props.sx,
       }}
     >
       <MuiCircularProgress

--- a/src/components/Stepper/VerticalStepper.tsx
+++ b/src/components/Stepper/VerticalStepper.tsx
@@ -113,11 +113,7 @@ export default function VerticalStepper({
           {title}
         </Typography>
       )}
-      <MuiStepper
-        activeStep={activeStep}
-        orientation="vertical"
-        connector={<StyledStepConnector />}
-      >
+      <MuiStepper activeStep={activeStep} connector={<StyledStepConnector />}>
         {steps.map((step, index) => {
           const activeStepIndex = activeStep || 0;
           const active = index === activeStepIndex;

--- a/src/components/Stepper/VerticalStepper.tsx
+++ b/src/components/Stepper/VerticalStepper.tsx
@@ -113,7 +113,11 @@ export default function VerticalStepper({
           {title}
         </Typography>
       )}
-      <MuiStepper activeStep={activeStep} connector={<StyledStepConnector />}>
+      <MuiStepper
+        activeStep={activeStep}
+        orientation="vertical"
+        connector={<StyledStepConnector />}
+      >
         {steps.map((step, index) => {
           const activeStepIndex = activeStep || 0;
           const active = index === activeStepIndex;


### PR DESCRIPTION
Breaking change since align will now be "alignItems" instead of "justifyContent"
I left the spinner component, I will do a clean-up next sprint of all the old components & stories 