### PR TITLE
changed colors for warning and text fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.20.10",
+  "version": "1.20.11-fix-better-warning-text-color.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.20.10",
+      "version": "1.20.11-fix-better-warning-text-color.0",
       "dependencies": {
         "@fontsource/material-icons": "^5.0.18",
         "@fontsource/roboto": "^5.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.20.10",
+  "version": "1.20.11-fix-better-warning-text-color.0",
   "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/src/components/AgronodInputs/AgronodTextField/AgronodTextField.tsx
+++ b/src/components/AgronodInputs/AgronodTextField/AgronodTextField.tsx
@@ -59,13 +59,19 @@ const StyledMuiTextField = ({
 }: AgronodTextFieldProps) => {
   const icon = useMemo(() => {
     if (rest.error && hasIcon) {
+      if (rest.disabled) {
+        return <AgronodIcon name="errorContained" color="disabled" />;
+      }
       return <AgronodIcon name="errorContained" color="error" />;
     } else if (rest.warning && hasIcon) {
+      if (rest.disabled) {
+        return <AgronodIcon name="warningContained" color="disabled" />;
+      }
       return <AgronodIcon name="warningContained" color="warning" />;
     } else {
       return null;
     }
-  }, [rest.error, rest.warning, hasIcon]);
+  }, [rest.error, rest.warning, rest.disabled, hasIcon]);
 
   return (
     <Box
@@ -151,10 +157,12 @@ const StyledMuiTextField = ({
       </Box>
       {!hideHelperText && helperText !== undefined && (
         <FormHelperText
-          error={rest.error}
-          sx={{
+          // error={rest.error} //removed in favour of own color definition below
+          disabled={rest.disabled}
+          sx={(theme) => ({
             width: rest.fullWidth ? "100%" : "220px",
-          }}
+            color: rest.error ? theme.palette.error.medium : (rest.warning ? theme.palette.warning.dark : theme.palette.text.secondary)
+          })}
         >
           {helperText}
         </FormHelperText>
@@ -209,7 +217,7 @@ const AgronodTextField = ({
               typography: {
                 variant: "body2bold",
                 alignSelf: "flex-start",
-                color: rest.error ? "error.medium" : "text.secondary",
+                color: rest.error ? "error.medium" : (rest.warning ? "warning.dark" : 'text.secondary'),
                 marginBottom: "4px",
               },
             }}

--- a/src/components/Theme/baseTheme.ts
+++ b/src/components/Theme/baseTheme.ts
@@ -124,7 +124,7 @@ const semanticThemePalette = {
     light: "#FBDCB7",
     main: "#ED9135",
     medium: "#E0732C",
-    dark: "#D65A26",
+    dark: "#C84801",
   },
   info: {
     pastel: "#F1ECE7",


### PR DESCRIPTION
## What does this change do? Explained to a 🐵
- Changed warning-dark color to be AA- WCAG compliant
- Changed TextField Helper texts for warning and error states so that contrast i good enough

## How have I tested this?

- [X] 😨 I tested it in my brain (This is fine. What could go wrong? 🔥😅)
- [X] 😬 Tested manually on my machine or in a deployed environment (Pushed buttons until it “felt” okay. 🤷‍♂️)
- [ ] 🏆 Automated tests (This is **real** testing. Be proud. 💪🚀)  
- [ ] ✏️ Other (please describe):

## Additional Context
