### PR TITLE
reduce padding for cards in mobile

### DIFF
--- a/src/components/Theme/baseTheme.ts
+++ b/src/components/Theme/baseTheme.ts
@@ -467,6 +467,9 @@ const baseThemeOptions: ThemeOptions = {
         root: {
           borderRadius: "16px",
           padding: "24px",
+          [defaultMuiTheme.breakpoints.down('sm')]: {
+            padding: "16px",
+          },
         },
       },
     },


### PR DESCRIPTION
## What does this change do? Explained to a 🐵
reduce padding for cards in mobile from 24px to 16px

## How have I tested this?

- [x] 😨 I tested it in my brain (This is fine. What could go wrong? 🔥😅)
- [x] 😬 Tested manually on my machine or in a deployed environment (Pushed buttons until it “felt” okay. 🤷‍♂️)
- [ ] 🏆 Automated tests (This is **real** testing. Be proud. 💪🚀)  
- [ ] ✏️ Other (please describe):

## Additional Context
