### PR TITLE
fix: added hint colors to agronod, agrosfar and baseTheme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.21.2-fix-pf-1174-added-hint-colors.0",
+  "version": "1.21.3-fix-pf-1174-added-hint-colors.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.21.2-fix-pf-1174-added-hint-colors.0",
+      "version": "1.21.3-fix-pf-1174-added-hint-colors.0",
       "dependencies": {
         "@fontsource/material-icons": "^5.0.18",
         "@fontsource/roboto": "^5.0.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.21.1-fix-pf-1174-added-hint-colors.0",
+  "version": "1.21.2-fix-pf-1174-added-hint-colors.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.21.1-fix-pf-1174-added-hint-colors.0",
+      "version": "1.21.2-fix-pf-1174-added-hint-colors.0",
       "dependencies": {
         "@fontsource/material-icons": "^5.0.18",
         "@fontsource/roboto": "^5.0.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.21.0",
+  "version": "1.21.1-fix-pf-1174-added-hint-colors.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@agronod/mui-components",
-      "version": "1.21.0",
+      "version": "1.21.1-fix-pf-1174-added-hint-colors.0",
       "dependencies": {
         "@fontsource/material-icons": "^5.0.18",
         "@fontsource/roboto": "^5.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.21.1-fix-pf-1174-added-hint-colors.0",
+  "version": "1.21.2-fix-pf-1174-added-hint-colors.0",
   "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.21.2-fix-pf-1174-added-hint-colors.0",
+  "version": "1.21.3-fix-pf-1174-added-hint-colors.0",
   "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agronod/mui-components",
-  "version": "1.21.0",
+  "version": "1.21.1-fix-pf-1174-added-hint-colors.0",
   "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/src/components/Theme/agronodTheme.ts
+++ b/src/components/Theme/agronodTheme.ts
@@ -1,8 +1,9 @@
 import { globalThemePalette } from "./baseTheme";
 import createPalette from "@mui/material/styles/createPalette";
 
-const agronodThemePalette = createPalette({
+const agronodThemePalette = {
   primary: {
+    hint: "#FFFBF0",
     pastel: "#FFF5D9",
     light: "#FDECB5",
     main: "#F2CB6C",
@@ -13,12 +14,12 @@ const agronodThemePalette = createPalette({
     darkHover: "#B37D2E",
   },
   ...globalThemePalette,
-});
+};
 
 const themePalette = createPalette(agronodThemePalette);
 
 const agronodTheme = {
-  palette: agronodThemePalette,
+  palette: themePalette,
   components: {
     MuiCheckbox: {
       styleOverrides: {

--- a/src/components/Theme/agrosfarTheme.ts
+++ b/src/components/Theme/agrosfarTheme.ts
@@ -3,6 +3,7 @@ import createPalette from "@mui/material/styles/createPalette";
 
 export const agrosfarThemePalette = {
   primary: {
+    hint: "#F3F9F7",
     pastel: "#E0F0EA",
     light: "#B4D9CA",
     main: "#2F8560",

--- a/src/components/Theme/baseTheme.ts
+++ b/src/components/Theme/baseTheme.ts
@@ -80,6 +80,7 @@ declare module "@mui/material/styles/" {
 
 declare module "@mui/material/styles/createPalette" {
   interface PaletteColor {
+    hint?: string;
     pastel?: string;
     mainHover?: string;
     medium?: string;

--- a/src/components/Theme/baseTheme.ts
+++ b/src/components/Theme/baseTheme.ts
@@ -112,6 +112,7 @@ const pxToRem = (fontSize: number) => {
 
 const semanticThemePalette = {
   error: {
+    hint: "#FEF7F8",
     pastel: "#FCECEE",
     light: "#F7C7D3",
     main: "#D4483E",
@@ -120,6 +121,7 @@ const semanticThemePalette = {
     darkHover: "#812B25",
   },
   warning: {
+    hint: "#FEF9F5",
     pastel: "#FDF0E6",
     light: "#FBDCB7",
     main: "#ED9135",
@@ -127,6 +129,7 @@ const semanticThemePalette = {
     dark: "#C84801",
   },
   info: {
+    hint: "#F9F7F5",
     pastel: "#F1ECE7",
     light: "#DAD0C7",
     main: "#68523D",
@@ -134,6 +137,7 @@ const semanticThemePalette = {
     dark: "#443023",
   },
   success: {
+    hint: "#F7FBF7",
     pastel: "#EAF5EA",
     light: "#CEE5CB",
     main: "#5D9D52",
@@ -142,6 +146,7 @@ const semanticThemePalette = {
     darkHover: "#21411C",
   },
   tertiary: {
+    hint: "#FBF6F5",
     pastel: "#F4E8E7",
     light: "#DAC7C8",
     main: "#7E474B",
@@ -149,6 +154,7 @@ const semanticThemePalette = {
     dark: "#3A1E25",
   },
   secondary: {
+    hint: "#F6F7FA",
     pastel: "#E8ECF2",
     light: "#C7D1DA",
     main: "#51697E",

--- a/src/components/Theme/baseTheme.ts
+++ b/src/components/Theme/baseTheme.ts
@@ -62,6 +62,7 @@ declare module "@mui/material/styles/createPalette" {
     white36: string;
     white50: string;
     tertiary: {
+      hint?: string;
       pastel: string;
       light: string;
       main: string;

--- a/src/designTokens/Colors/Colors.stories.tsx
+++ b/src/designTokens/Colors/Colors.stories.tsx
@@ -53,6 +53,8 @@ export const ColorPalette = () => {
         <ColorItem name=".main" code={theme.palette.primary.main} />
         <ColorItem name=".light" code={theme.palette.primary.light} />
         <ColorItem name=".pastel" code={theme.palette.primary.pastel} />
+        <ColorItem name=".hint" code={theme.palette.primary.hint} />
+
       </Stack>
 
       <AgronodTypography
@@ -70,6 +72,8 @@ export const ColorPalette = () => {
         <ColorItem name=".main" code={theme.palette.secondary.main} />
         <ColorItem name=".light" code={theme.palette.secondary.light} />
         <ColorItem name=".pastel" code={theme.palette.secondary.pastel} />
+        <ColorItem name=".hint" code={theme.palette.secondary.hint} />
+
       </Stack>
 
       <AgronodTypography
@@ -87,6 +91,7 @@ export const ColorPalette = () => {
         <ColorItem name=".main" code={theme.palette.tertiary.main} />
         <ColorItem name=".light" code={theme.palette.tertiary.light} />
         <ColorItem name=".pastel" code={theme.palette.tertiary.pastel} />
+        <ColorItem name=".hint" code={theme.palette.tertiary.hint} />
       </Stack>
 
       <AgronodTypography variant="h3" sx={{ marginBottom: 3, marginTop: 6 }}>
@@ -109,6 +114,7 @@ export const ColorPalette = () => {
         <ColorItem name=".main" code={theme.palette.success.main} />
         <ColorItem name=".light" code={theme.palette.success.light} />
         <ColorItem name=".pastel" code={theme.palette.success.pastel} />
+        <ColorItem name=".hint" code={theme.palette.success.hint} />
       </Stack>
 
       <AgronodTypography
@@ -126,6 +132,7 @@ export const ColorPalette = () => {
         <ColorItem name=".main" code={theme.palette.warning.main} />
         <ColorItem name=".light" code={theme.palette.warning.light} />
         <ColorItem name=".pastel" code={theme.palette.warning.pastel} />
+        <ColorItem name=".hint" code={theme.palette.warning.hint} />
       </Stack>
 
       <AgronodTypography
@@ -144,6 +151,7 @@ export const ColorPalette = () => {
         <ColorItem name=".main" code={theme.palette.error.main} />
         <ColorItem name=".light" code={theme.palette.error.light} />
         <ColorItem name=".pastel" code={theme.palette.error.pastel} />
+        <ColorItem name=".hint" code={theme.palette.error.hint} />
       </Stack>
 
       <AgronodTypography
@@ -161,6 +169,7 @@ export const ColorPalette = () => {
         <ColorItem name=".main" code={theme.palette.info.main} />
         <ColorItem name=".light" code={theme.palette.info.light} />
         <ColorItem name=".pastel" code={theme.palette.info.pastel} />
+        <ColorItem name=".hint" code={theme.palette.info.hint} />
       </Stack>
 
       <AgronodTypography variant="h3" sx={{ marginBottom: 3, marginTop: 6 }}>


### PR DESCRIPTION
## What does this change do? Explained to a 🐵

- added hint colors to agronod, agrosfar and baseTheme

## How have I tested this?

- [x] 😨 I tested it in my brain (This is fine. What could go wrong? 🔥😅)
- [x] 😬 Tested manually on my machine or in a deployed environment (Pushed buttons until it “felt” okay. 🤷‍♂️)
- [ ] 🏆 Automated tests (This is **real** testing. Be proud. 💪🚀)  
- [ ] ✏️ Other (please describe):

## Additional Context
